### PR TITLE
adding pip install requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+argparse==1.3.0
+xlrd==0.9.3
+pdfminer==20140328


### PR DESCRIPTION
Wanted to add requirements.txt so people can just clone, pip install so that they are just able to use Forager right out of the box. This way users do not have to go looking for needed packages to get Forager to work based on import errors :) 
